### PR TITLE
don't hide google analytics code from storage layer

### DIFF
--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/content_title.cpt
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/content_title.cpt
@@ -162,7 +162,7 @@
 
         </fieldset>
 
-        <input type="hidden" name="license" value="http://creativecommons.org/licenses/by/3.0/"
+        <input type="hidden" name="license" value="http://creativecommons.org/licenses/by/4.0/"
                 tal:attributes="value request/license | here/getDefaultLicense" />
 
         <input type="submit"

--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishContent.cpy
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishContent.cpy
@@ -39,12 +39,6 @@ if hasattr(context,'excludedIds'):
     if excludedexists:
         context.manage_delObjects(excludedexists)
 
-# remove Google Analytics Tracking Code from object
-GoogleAnalyticsTrackingCode = None
-if hasattr(context, 'GoogleAnalyticsTrackingCode'):
-    GoogleAnalyticsTrackingCode = context.getGoogleAnalyticsTrackingCode()
-    context.setGoogleAnalyticsTrackingCode(None)
-
 # publish/republish module
 if newpublish:
     context.setBaseObject(repo.publishObject(context, message))
@@ -52,6 +46,13 @@ if newpublish:
 else:
     object = repo.getRhaptosObject(context.objectId)
     repo.publishRevision(context, message)
+
+# remove Google Analytics Tracking Code from object
+GoogleAnalyticsTrackingCode = None
+if hasattr(context, 'GoogleAnalyticsTrackingCode'):
+    GoogleAnalyticsTrackingCode = context.getGoogleAnalyticsTrackingCode()
+    context.setGoogleAnalyticsTrackingCode(None)
+
 
 # place Google Analytics Tracking Code into object's published folder
 if GoogleAnalyticsTrackingCode is not None:


### PR DESCRIPTION
Don't hide the GA code - lower layer can now handle it. Needs Rhaptos/Products.RhaptosModuleStorage/pull/6
