### PR TITLE
Revert "collection publish checks - not empty, no repeating chapter t…

### DIFF
--- a/Products/RhaptosModuleEditor/CHANGES.txt
+++ b/Products/RhaptosModuleEditor/CHANGES.txt
@@ -1,8 +1,8 @@
 RhaptosModuleEditor-0.86
-  - Fix syntax and code errors in publishBlocked.py :-(
+  - REVERTED Fix syntax and code errors in publishBlocked.py :-(
 
 RhaptosModuleEditor-0.85
-  - Don't allow bad collections to be published - empty or with duplicate chapter names
+  - REVERTED Don't allow bad collections to be published - empty or with duplicate chapter names
 
 RhaptosModuleEditor-0.84
   - Plone hotfix restricted attribute access to subobjects: convert property access to getProperty calls

--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishBlocked.py
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishBlocked.py
@@ -10,10 +10,14 @@
 
 err = {'failtype':None, 'faildata':None}  # return value template
 
-# Title check; used to be in getContentOverridePage.py
-title = context.Title()
-if (not title) or title == '(Untitled)':
-    err['failtype'] = 'notitle'
+# Check moduleness and short-circuit if collection
+if not context.portal_type == 'Module':
+    return False
+
+# Missing index file check
+indexcnxml = versioninfo['indexcnxml']
+if not indexcnxml:
+    err['failtype'] = 'noindex'
     return err
 
 # Checks to see if there's a published version of this object
@@ -27,80 +31,6 @@ if latest:
         err['faildata'] = {'thisversion':context.version, 'pubversion':latest.version}
         return err
 
-# Maintainership check
-from AccessControl import getSecurityManager
-cur_user = getSecurityManager().getUser().getUserName()
-# pubobj is defined above, in "superseded check", and tells us whether there's a published version or not
-if pubobj:
-    haspermission = context.portal_membership.checkPermission('Edit Rhaptos Object', pubobj)
-else:
-    # cur_user is defined above
-    haspermission = cur_user in context.maintainers or context.portal_membership.checkPermission('Edit Rhaptos Object', context)
-
-if not haspermission:
-    err['failtype'] = 'notmaint'
-    return err
-
-# Publishing check
-
-if not context.portal_membership.checkPermission('Publish Rhaptos Object', context):
-    err['failtype'] = 'notpub'
-    return err
-
-# Latest license present
-current_license = context.getProperty('license') or ''
-
-if current_license == '':
-    err['failtype'] = 'nolicense'
-    return err
-elif current_license != context.getDefaultLicense(current_license):
-    err['failtype'] = 'oldlicense'
-    err['faildata'] = {'current_license':current_license,'default_license':context.getDefaultLicense(current_license)}
-    return err
-
-# Checks for collections only
-if context.portal_type == 'Collection':
-    # Disallow Empty Collections - no modules
-    nodes = context.objectValues(['SubCollection','PublishedContentPointer'])
-    if nodes == []:
-        err['failtype'] = 'nocontent'
-        return err
-
-    # Check for dup chapter/unit titles:
-    chap_titles = [c.Title() for c in context.objectValues(['SubCollection'])]
-    if '(Untitled)' in chap_titles:
-        err['failtype'] = 'notitle'
-        return err
-
-    dup_titles = [t for t in chap_titles if chap_titles.count(t)]
-    if dup_titles != []:
-        err['failtype'] = 'duptitle'
-        err['faildata'] = {}.fromkeys(dup_titles).keys()
-        return err
-
-    # Go one level deeper (can't write proper recursion in restrictedPython
-    for unit in [c.Title() for c in context.objectValues(['SubCollection'])]:
-        chap_titles = [c.Title() for c in unit.objectValues(['SubCollection'])]
-        if '(Untitled)' in chap_titles:
-            err['failtype'] = 'notitle'
-            return err
-
-        dup_titles = [t for t in chap_titles if chap_titles.count(t)]
-        if dup_titles != []:
-            err['failtype'] = 'duptitle'
-            err['faildata'] = {}.fromkeys(dup_titles).keys()
-            return err
-
-    # Done w/ collection checks
-    return False
-
-# Module specific checks
-# Missing index file check
-indexcnxml = versioninfo['indexcnxml']
-if not indexcnxml:
-    err['failtype'] = 'noindex'
-    return err
-
 # Now that we know we have an index file, get its CNXML version
 cnxmlvers = versioninfo['cnxmlvers']
 
@@ -110,6 +40,8 @@ if cnxmlvers == None:
     return err
 
 # Load in list of messages this user has already seen and dismissed for this object
+from AccessControl import getSecurityManager
+cur_user = getSecurityManager().getUser().getUserName()
 allmsgs = getattr(context, 'messagesDismissed', {})
 if allmsgs.has_key(cur_user):
   messagesDismissed = allmsgs[cur_user]
@@ -138,6 +70,41 @@ if cnxmlvers == '0.5' or cnxmlvers == '0.6':
 if cnxmlvers < '0.5':
     err['failtype'] = 'olderversion'
     err['faildata'] = {'cnxmlversion':cnxmlvers}
+    return err
+
+# Title check; used to be in getContentOverridePage.py
+title = context.Title()
+if (not title) or title == '(Untitled)':
+    err['failtype'] = 'notitle'
+    return err
+
+# Maintainership check
+# pubobj is defined above, in "superseded check", and tells us whether there's a published version or not
+if pubobj:
+    haspermission = context.portal_membership.checkPermission('Edit Rhaptos Object', pubobj)
+else:
+    # cur_user is defined above the upconversion check
+    haspermission = cur_user in context.maintainers or context.portal_membership.checkPermission('Edit Rhaptos Object', context)
+
+if not haspermission:
+    err['failtype'] = 'notmaint'
+    return err
+
+# Publishing check
+
+if not context.portal_membership.checkPermission('Publish Rhaptos Object', context):
+    err['failtype'] = 'notpub'
+    return err
+
+# Latest license present
+current_license = context.getProperty('license') or ''
+
+if current_license == '':
+    err['failtype'] = 'nolicense'
+    return err
+elif current_license != context.getDefaultLicense(current_license):
+    err['failtype'] = 'oldlicense'
+    err['faildata'] = {'current_license':current_license,'default_license':context.getDefaultLicense(current_license)}
     return err
 
 # Default return in normal case

--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/unpublishable.pt
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/unpublishable.pt
@@ -23,10 +23,10 @@
             for additional details.
           </span>
         </div>
-
+        
         <div tal:condition="publishblocked"
              tal:define="notetype python:test(publishtemplate, 'PUBLISH BLOCKED', 'WARNING');
-                         baderrors python:['cnxmlfivedismissed', 'superseded', 'noindex', 'notcnxml','nolicense','oldlicense','nocontent', 'duptitle'];
+                         baderrors python:['cnxmlfivedismissed', 'superseded', 'noindex', 'notcnxml','nolicense','oldlicense'];
                          color python:test(publisherror in baderrors, 'yellow', '#fe7');
                          stylestring python:'border: 2px solid #e70;; background-color: %s;; padding: 0.5em;; margin: 0.5em 0;;' % color">
           <tal:block tal:condition="python:publisherror=='cnxmlfivedismissed'">
@@ -48,7 +48,6 @@ roles, or links. The conversion process will generate a temporary backup.
 </form>
   </div>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='cnxmlfive'">
             <tal:external define="global readonly python:True" />
             <div tal:attributes="style stylestring">
@@ -64,10 +63,10 @@ automatically be in the new language version.</li>
 automatically be converted to the new version.</li>
       <li><b>Open Full Source Editor</b>: You can postpone the upgrade and continue to make changes to your existing CNXML,
        but you will still have to upgrade before publishing. See below for a list of other functions that are disabled until 
-       upgrade.</li>
+upgrade.
     </ul>
-  </p>
-
+  <p>
+    
   <form action="." method="post"
         style="margin-top: 1em; margin-bottom: 0.5em; text-align: center">
     <input class="context" style="margin-right: 0.5em; font-size: 110%" type="submit"              
@@ -138,7 +137,6 @@ published version is <span tal:replace="publishedVersion">1.1</span>.
 </div>
             </tal:define>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='olderversion'">
             <tal:define tal:define="cnxmlversion publisherrorfaildata/cnxmlversion">
             <div tal:attributes="style stylestring">
@@ -150,7 +148,6 @@ of the tag structure may be invalid.
 </div>
             </tal:define>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='notcnxml'">
             <tal:block tal:define="blank python:len(context.getDefaultFile().getSource()) &lt;= 1">
             <div tal:attributes="style stylestring">
@@ -161,7 +158,6 @@ of the import options to generate new contents for the module.
 </div>
             </tal:block>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='noindex'">
             <div tal:attributes="style stylestring">
 
@@ -170,7 +166,6 @@ href="confirm_discard">discard</a> the module and start over, or use one of the 
 the module.
 </div>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='notitle'">
             <div tal:attributes="style stylestring">
 
@@ -178,29 +173,12 @@ the module.
 you enter a title on the <a href="module_metadata">metadata page</a>.
 </div>
           </tal:block>
-
-          <tal:block tal:condition="python:publisherror=='nocontent'">
-            <div tal:attributes="style stylestring">
-
-<b tal:content="string:${notetype}:">WARNING:</b> This collection has no content. You will not be able to publish until you add some.
-</div>
-          </tal:block>
-
-          <tal:block tal:condition="python:publisherror=='duptitle'">
-            <div tal:attributes="style stylestring">
-
-                <b tal:content="string:${notetype}:">WARNING:</b> This collection contains multiple chapters with the same title: <span tal:content="python:publisherrorfaildata"> duplicate titles here</span> You will not be able to publish until you change them to be unique.
-
-</div>
-          </tal:block>
-
           <tal:block tal:condition="python:publisherror=='nolicense' and publishtemplate">
             <div tal:attributes="style stylestring">
 
 <b tal:content="string:${notetype}:">WARNING:</b> You have not yet agreed to a license for this content. Please <a href="module_publish">do so</a> now.
 </div>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='oldlicense' and publishtemplate">
             <div tal:attributes="style stylestring">
 
@@ -210,7 +188,6 @@ you enter a title on the <a href="module_metadata">metadata page</a>.
                 >accept the new license</a> prior to publishing.
 </div>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='notmaint' and publishtemplate">
             <div tal:attributes="style stylestring">
 
@@ -227,7 +204,6 @@ of this object, so you will not be able to publish the current revision. Other o
 </p>
 </div>
           </tal:block>
-
           <tal:block tal:condition="python:publisherror=='notpub' and publishtemplate">
             <div tal:attributes="style stylestring">
 


### PR DESCRIPTION
…itles"

Turns not that this code is nto called on the publish collection path, anyway. Reverting back to 0.84, which is currently released code. Only diff is CHANGES.txt and versions.txt have traces of 0.85 and 0.86 in them.