### PR TITLE
disallow empty chapters and duplicate chapter names for collections

### DIFF
--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishBlocked.py
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishBlocked.py
@@ -10,14 +10,10 @@
 
 err = {'failtype':None, 'faildata':None}  # return value template
 
-# Check moduleness and short-circuit if collection
-if not context.portal_type == 'Module':
-    return False
-
-# Missing index file check
-indexcnxml = versioninfo['indexcnxml']
-if not indexcnxml:
-    err['failtype'] = 'noindex'
+# Title check; used to be in getContentOverridePage.py
+title = context.Title()
+if (not title) or title == '(Untitled)':
+    err['failtype'] = 'notitle'
     return err
 
 # Checks to see if there's a published version of this object
@@ -31,6 +27,94 @@ if latest:
         err['faildata'] = {'thisversion':context.version, 'pubversion':latest.version}
         return err
 
+# Maintainership check
+from AccessControl import getSecurityManager
+cur_user = getSecurityManager().getUser().getUserName()
+# pubobj is defined above, in "superseded check", and tells us whether there's a published version or not
+if pubobj:
+    haspermission = context.portal_membership.checkPermission('Edit Rhaptos Object', pubobj)
+else:
+    # cur_user is defined above
+    haspermission = cur_user in context.maintainers or context.portal_membership.checkPermission('Edit Rhaptos Object', context)
+
+if not haspermission:
+    err['failtype'] = 'notmaint'
+    return err
+
+# Publishing check
+
+if not context.portal_membership.checkPermission('Publish Rhaptos Object', context):
+    err['failtype'] = 'notpub'
+    return err
+
+# Checks for collections only
+if context.portal_type == 'Collection':
+    # Disallow Empty Collections - no modules
+    nodes = context.objectValues(['SubCollection','PublishedContentPointer'])
+    if nodes == []:
+        err['failtype'] = 'nocontent'
+        return err
+
+    # Check for dup chapter/unit titles:
+    chap_titles = [c.Title() for c in context.objectValues(['SubCollection'])]
+    if '(Untitled)' in chap_titles:
+        err['failtype'] = 'notitle'
+        return err
+
+    dup_titles = [t for t in chap_titles if chap_titles.count(t) > 1]
+    if dup_titles != []:
+        err['failtype'] = 'duptitle'
+        err['faildata'] = {}.fromkeys(dup_titles).keys()
+        return err
+
+    # Go one level deeper (can't write proper recursion in restrictedPython
+    for unit in context.objectValues(['SubCollection']):
+        # Check for empty top-level chapters (units)
+        nodes = unit.objectValues(['SubCollection','PublishedContentPointer'])
+        if nodes == []:
+            err['failtype'] = 'emptychap'
+            err['faildata'] = unit.getTitle()
+            return err
+        for chap in unit.objectValues(['SubCollection']):
+            # Check for empty second-level chapters
+            nodes = chap.objectValues(['SubCollection','PublishedContentPointer'])
+            if nodes == []:
+                err['failtype'] = 'emptychap'
+                err['faildata'] = chap.getTitle()
+                return err
+
+        chap_titles = [c.Title() for c in unit.objectValues(['SubCollection'])]
+        if '(Untitled)' in chap_titles:
+            err['failtype'] = 'notitle'
+            return err
+
+        dup_titles = [t for t in chap_titles if chap_titles.count(t) > 1]
+        if dup_titles != []:
+            err['failtype'] = 'duptitle'
+            err['faildata'] = {}.fromkeys(dup_titles).keys()
+            return err
+
+    # Done w/ collection checks
+    return False
+
+# Module specific checks
+# Latest license present - collections do license checks in canPublish and publish_collection
+current_license = context.getProperty('license') or context.license or ''
+
+if current_license == '':
+    err['failtype'] = 'nolicense'
+    return err
+elif current_license != context.getDefaultLicense(current_license):
+    err['failtype'] = 'oldlicense'
+    err['faildata'] = {'current_license':current_license,'default_license':context.getDefaultLicense(current_license)}
+    return err
+
+# Missing index file check
+indexcnxml = versioninfo['indexcnxml']
+if not indexcnxml:
+    err['failtype'] = 'noindex'
+    return err
+
 # Now that we know we have an index file, get its CNXML version
 cnxmlvers = versioninfo['cnxmlvers']
 
@@ -40,8 +124,6 @@ if cnxmlvers == None:
     return err
 
 # Load in list of messages this user has already seen and dismissed for this object
-from AccessControl import getSecurityManager
-cur_user = getSecurityManager().getUser().getUserName()
 allmsgs = getattr(context, 'messagesDismissed', {})
 if allmsgs.has_key(cur_user):
   messagesDismissed = allmsgs[cur_user]
@@ -70,41 +152,6 @@ if cnxmlvers == '0.5' or cnxmlvers == '0.6':
 if cnxmlvers < '0.5':
     err['failtype'] = 'olderversion'
     err['faildata'] = {'cnxmlversion':cnxmlvers}
-    return err
-
-# Title check; used to be in getContentOverridePage.py
-title = context.Title()
-if (not title) or title == '(Untitled)':
-    err['failtype'] = 'notitle'
-    return err
-
-# Maintainership check
-# pubobj is defined above, in "superseded check", and tells us whether there's a published version or not
-if pubobj:
-    haspermission = context.portal_membership.checkPermission('Edit Rhaptos Object', pubobj)
-else:
-    # cur_user is defined above the upconversion check
-    haspermission = cur_user in context.maintainers or context.portal_membership.checkPermission('Edit Rhaptos Object', context)
-
-if not haspermission:
-    err['failtype'] = 'notmaint'
-    return err
-
-# Publishing check
-
-if not context.portal_membership.checkPermission('Publish Rhaptos Object', context):
-    err['failtype'] = 'notpub'
-    return err
-
-# Latest license present
-current_license = context.getProperty('license') or ''
-
-if current_license == '':
-    err['failtype'] = 'nolicense'
-    return err
-elif current_license != context.getDefaultLicense(current_license):
-    err['failtype'] = 'oldlicense'
-    err['faildata'] = {'current_license':current_license,'default_license':context.getDefaultLicense(current_license)}
     return err
 
 # Default return in normal case

--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishContent.cpy.metadata
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/publishContent.cpy.metadata
@@ -1,4 +1,5 @@
 [actions]
 action.success = redirect_to_action:string:view
+action.error = redirect_to_action:string:publish
 action.select_col_lens = redirect_to:string:collection_publish_selectlens
 action.select_lens = redirect_to:string:module_publish_selectlens

--- a/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/unpublishable.pt
+++ b/Products/RhaptosModuleEditor/skins/rhaptos_module_editor/unpublishable.pt
@@ -9,7 +9,8 @@
                              publishblocked publishBlocked | python:context.publishBlocked(versioninfo);
                              publisherror publishblocked/failtype | nothing;
                              publisherrorfaildata publishblocked/faildata | nothing;
-                             publishtemplate python:template.id=='module_publish_description'">
+                             publishtemplate python:template.id=='module_publish_description'
+                                                 or template.id=='collection_publish'">
         <div tal:condition="upgrade"
              style="border: 1px solid #e70; background-color: #fdf3e8; padding: .5em; margin: 1em 0; font-size: .9em;">
           This module has been automatically upgraded to CNXML 0.7, which is the latest version of the language.
@@ -23,10 +24,10 @@
             for additional details.
           </span>
         </div>
-        
+
         <div tal:condition="publishblocked"
              tal:define="notetype python:test(publishtemplate, 'PUBLISH BLOCKED', 'WARNING');
-                         baderrors python:['cnxmlfivedismissed', 'superseded', 'noindex', 'notcnxml','nolicense','oldlicense'];
+                         baderrors python:['cnxmlfivedismissed', 'superseded', 'noindex', 'notcnxml','nolicense','oldlicense','nocontent', 'emptychap', 'duptitle'];
                          color python:test(publisherror in baderrors, 'yellow', '#fe7');
                          stylestring python:'border: 2px solid #e70;; background-color: %s;; padding: 0.5em;; margin: 0.5em 0;;' % color">
           <tal:block tal:condition="python:publisherror=='cnxmlfivedismissed'">
@@ -48,6 +49,7 @@ roles, or links. The conversion process will generate a temporary backup.
 </form>
   </div>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='cnxmlfive'">
             <tal:external define="global readonly python:True" />
             <div tal:attributes="style stylestring">
@@ -55,7 +57,7 @@ roles, or links. The conversion process will generate a temporary backup.
 <h1>CNXML Upgrade Needed</h1>
 
   <p>We are moving to the new version 0.7 of CNXML.
-    <b>You need to upgrade this module</b> to version 0.7 before you can publish it or make metadata changes.  You have three options:
+    <b>You need to upgrade this module</b> to version 0.7 before you can publish it or make metadata changes.  You have three options:</p>
     <ul>
       <li><b>Import</b>: If you are using one of the importers to create your content, import as usual; the result will 
 automatically be in the new language version.</li>
@@ -63,10 +65,9 @@ automatically be in the new language version.</li>
 automatically be converted to the new version.</li>
       <li><b>Open Full Source Editor</b>: You can postpone the upgrade and continue to make changes to your existing CNXML,
        but you will still have to upgrade before publishing. See below for a list of other functions that are disabled until 
-upgrade.
+       upgrade.</li>
     </ul>
-  <p>
-    
+
   <form action="." method="post"
         style="margin-top: 1em; margin-bottom: 0.5em; text-align: center">
     <input class="context" style="margin-right: 0.5em; font-size: 110%" type="submit"              
@@ -137,6 +138,7 @@ published version is <span tal:replace="publishedVersion">1.1</span>.
 </div>
             </tal:define>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='olderversion'">
             <tal:define tal:define="cnxmlversion publisherrorfaildata/cnxmlversion">
             <div tal:attributes="style stylestring">
@@ -148,6 +150,7 @@ of the tag structure may be invalid.
 </div>
             </tal:define>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='notcnxml'">
             <tal:block tal:define="blank python:len(context.getDefaultFile().getSource()) &lt;= 1">
             <div tal:attributes="style stylestring">
@@ -158,6 +161,7 @@ of the import options to generate new contents for the module.
 </div>
             </tal:block>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='noindex'">
             <div tal:attributes="style stylestring">
 
@@ -166,6 +170,7 @@ href="confirm_discard">discard</a> the module and start over, or use one of the 
 the module.
 </div>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='notitle'">
             <div tal:attributes="style stylestring">
 
@@ -173,12 +178,36 @@ the module.
 you enter a title on the <a href="module_metadata">metadata page</a>.
 </div>
           </tal:block>
+
+          <tal:block tal:condition="python:publisherror=='nocontent'">
+            <div tal:attributes="style stylestring">
+
+<b tal:content="string:${notetype}:">WARNING:</b> This collection has no content. You will not be able to publish until you add some.
+</div>
+          </tal:block>
+
+          <tal:block tal:condition="python:publisherror=='emptychap'">
+            <div tal:attributes="style stylestring">
+
+<b tal:content="string:${notetype}:">WARNING:</b> The subcollection <b tal:content='python:publisherrorfaildata'>Empty Chapter</b> has no content. You will not be able to publish until you add some, or delete it.
+</div>
+          </tal:block>
+
+          <tal:block tal:condition="python:publisherror=='duptitle'">
+            <div tal:attributes="style stylestring">
+
+                <b tal:content="string:${notetype}:">WARNING:</b> This collection contains multiple chapters with the same title: <tal:dups tal:repeat="duptitle python:publisherrorfaildata"><b tal:content='duptitle'>duplicate titles here</b><tal:comma tal:condition='not:repeat/duptitle/end'>, </tal:comma></tal:dups> You will not be able to publish until you change them to be unique.
+
+</div>
+          </tal:block>
+
           <tal:block tal:condition="python:publisherror=='nolicense' and publishtemplate">
             <div tal:attributes="style stylestring">
 
 <b tal:content="string:${notetype}:">WARNING:</b> You have not yet agreed to a license for this content. Please <a href="module_publish">do so</a> now.
 </div>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='oldlicense' and publishtemplate">
             <div tal:attributes="style stylestring">
 
@@ -188,6 +217,7 @@ you enter a title on the <a href="module_metadata">metadata page</a>.
                 >accept the new license</a> prior to publishing.
 </div>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='notmaint' and publishtemplate">
             <div tal:attributes="style stylestring">
 
@@ -204,6 +234,7 @@ of this object, so you will not be able to publish the current revision. Other o
 </p>
 </div>
           </tal:block>
+
           <tal:block tal:condition="python:publisherror=='notpub' and publishtemplate">
             <div tal:attributes="style stylestring">
 


### PR DESCRIPTION
This PR puts back most of what was reverted by the previous commit, but with fixes. The main difference is noticing that canPublish was being called from publishContent, but since RhaptosModuleEditor calls canPublish on every single tab in the editor interface and invokes a problem-solving sub-page (from the unpublishable.pt template), it's not possible to get to the failure path when publishing a module: the errors have already been dealt with. This was not true for collections. So I added an `action.error = redirect_to_action:string:publish`  to get past that. In addition, I found one more syntax error in the unpublishable template (self closing `p` because of an embedded list). There is a companion PR to make use of these changes  Rhaptos/Products.RhaptosCollection#11